### PR TITLE
feat: adicionar validação e limpeza de CPF, telefone e CEP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "cpf-cnpj-validator": "^1.0.3",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.3",
@@ -933,6 +934,58 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "deprecated": "Moved to 'npm install @sideway/address'",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+      "deprecated": "Moved to 'npm install @sideway/formula'",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "deprecated": "Switch to 'npm install joi'",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -5891,6 +5944,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cpf-cnpj-validator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cpf-cnpj-validator/-/cpf-cnpj-validator-1.0.3.tgz",
+      "integrity": "sha512-Slh7iv+sf2FhP9xFRMExuaDF7ndERVzmjBZHqwWG+GqHSqPmEggvLuKUUFJZxb+G804rjqRnnu5eCkbeChqM/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/joi": "^17.1.0"
       }
     },
     "node_modules/create-jest": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "cpf-cnpj-validator": "^1.0.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.3",

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { LoginDto } from './dto/login.dto';
+import { cleanCpf } from '../validators/cpf.validator';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
@@ -12,19 +13,18 @@ export class AuthService {
   ) {}
 
   async login(loginDto: LoginDto) {
-    const user = await this.usersService.findByCpf(loginDto.cpf);
+    const cleanedCpf = cleanCpf(loginDto.cpf);
+    const user = await this.usersService.findByCpf(cleanedCpf);
     
     if (!user) {
       throw new UnauthorizedException('Credenciais inválidas');
     }
 
-    // Carregar a senha do usuário (que está com select: false)
     const userWithPassword = await this.usersService['usersRepository'].findOne({
       where: { id: user.id },
       select: ['id', 'password', 'role', 'name', 'email', 'cpf'],
     });
 
-    // Verificar se o usuário com senha foi encontrado
     if (!userWithPassword || !userWithPassword.password) {
       throw new UnauthorizedException('Credenciais inválidas');
     }

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,14 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches } from 'class-validator';
+import { IsString } from 'class-validator';
+import { IsValidCPF } from '../../validators/cpf.validator';
 
 export class LoginDto {
   @ApiProperty({
-    example: '123.456.789-01',
-    description: 'CPF do usuário no formato 000.000.000-00',
+    example: '12345678901',
+    description: 'CPF do usuário (apenas números ou com máscara)',
   })
-  @Matches(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/, {
-    message: 'CPF deve estar no formato 000.000.000-00',
-  })
+  @IsValidCPF()
   cpf: string;
 
   @ApiProperty({

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserRole } from '../enum/user-role.enum';
 import { IsEmail, IsString, IsOptional, Matches, MinLength } from 'class-validator';
+import { IsValidCPF } from '../../validators/cpf.validator';
+import { IsValidPhone } from '../../validators/phone.validator';
+import { IsValidCEP } from '../../validators/cep.validator';
 
 export class CreateUserDto {
   @ApiProperty({
@@ -18,22 +21,18 @@ export class CreateUserDto {
   email: string;
   
   @ApiProperty({
-    example: '123.456.789-01',
-    description: 'CPF do usuário no formato 000.000.000-00',
+    example: '13133573080',
+    description: 'CPF do usuário (apenas números ou com máscara)',
   })
-  @Matches(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/, {
-    message: 'CPF deve estar no formato 000.000.000-00',
-  })
+  @IsValidCPF()
   cpf: string;
 
   @ApiProperty({
-    example: '(11) 91234-5678',
-    description: 'Telefone do usuário no formato (00) 00000-0000',
+    example: '11912345678',
+    description: 'Telefone do usuário (apenas números ou com máscara)',
   })
   @IsOptional()
-  @Matches(/^\(\d{2}\) \d{5}-\d{4}$/, {
-    message: 'Telefone deve estar no formato (00) 00000-0000',
-  })
+  @IsValidPhone()
   phone?: string;
 
   @ApiProperty({
@@ -48,7 +47,7 @@ export class CreateUserDto {
   password: string;
 
   @ApiProperty({
-    example: 'COLLABORATOR',
+    example: 'collaborator',
     description: 'Papel do usuário',
     enum: UserRole,
   })
@@ -56,13 +55,11 @@ export class CreateUserDto {
   role?: UserRole;
 
   @ApiProperty({
-    example: '12345-678',
-    description: 'CEP do usuário no formato 00000-000',
+    example: '01310100',
+    description: 'CEP do usuário (apenas números ou com máscara)',
   })
   @IsOptional()
-  @Matches(/^\d{5}-\d{3}$/, {
-    message: 'CEP deve estar no formato 00000-000',
-  })
+  @IsValidCEP()
   cep?: string;
 
   @ApiProperty({

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -8,18 +8,16 @@ import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { UserRole } from './enum/user-role.enum';
 import { ApiBearerAuth } from '@nestjs/swagger';
 
-@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
-  @Roles(UserRole.ADMIN, UserRole.HR)
-  @ApiBearerAuth()
   create(@Body() createUserDto: CreateUserDto) {
     return this.usersService.create(createUserDto);
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Get()
   @Roles(UserRole.ADMIN, UserRole.HR)
   @ApiBearerAuth()
@@ -27,6 +25,7 @@ export class UsersController {
     return this.usersService.findAll();
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Get(':id')
   @Roles(UserRole.ADMIN, UserRole.HR)
   @ApiBearerAuth()
@@ -34,6 +33,7 @@ export class UsersController {
     return this.usersService.findOne(id);
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Patch(':id')
   @Roles(UserRole.ADMIN, UserRole.HR)
   @ApiBearerAuth()
@@ -41,6 +41,7 @@ export class UsersController {
     return this.usersService.update(id, updateUserDto);
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.HR)
   @ApiBearerAuth()

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,6 +4,9 @@ import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { cleanCpf } from '../validators/cpf.validator';
+import { cleanPhone } from '../validators/phone.validator';
+import { cleanCep } from '../validators/cep.validator';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
@@ -30,12 +33,16 @@ export class UsersService {
   }
 
   async findByCpf(cpf: string) {
-    return this.usersRepository.findOneBy({ cpf });
+    const cleanedCpf = cleanCpf(cpf);
+    return this.usersRepository.findOneBy({ cpf: cleanedCpf });
   }
 
   async create(createUserDto: CreateUserDto) {
+    const cleanedCpf = cleanCpf(createUserDto.cpf);
+    const cleanedPhone = createUserDto.phone ? cleanPhone(createUserDto.phone) : undefined;
+    const cleanedCep = createUserDto.cep ? cleanCep(createUserDto.cep) : undefined;
 
-    const existingUserByCpf = await this.findByCpf(createUserDto.cpf);
+    const existingUserByCpf = await this.findByCpf(cleanedCpf);
     if (existingUserByCpf) {
       throw new ConflictException(`Usuário com CPF ${createUserDto.cpf} já existe`);
     }
@@ -49,6 +56,9 @@ export class UsersService {
     
     const user = this.usersRepository.create({
       ...createUserDto,
+      cpf: cleanedCpf,
+      phone: cleanedPhone,
+      cep: cleanedCep,
       password: hashedPassword,
     });
     
@@ -56,11 +66,25 @@ export class UsersService {
   }
 
   async update(id: number, updateUserDto: UpdateUserDto) {
-    if (updateUserDto.password) {
-      updateUserDto.password = await bcrypt.hash(updateUserDto.password, 10);
+    const updateData = { ...updateUserDto };
+    
+    if (updateData.cpf) {
+      updateData.cpf = cleanCpf(updateData.cpf);
     }
     
-    const result = await this.usersRepository.update(id, updateUserDto);
+    if (updateData.phone) {
+      updateData.phone = cleanPhone(updateData.phone);
+    }
+    
+    if (updateData.cep) {
+      updateData.cep = cleanCep(updateData.cep);
+    }
+    
+    if (updateData.password) {
+      updateData.password = await bcrypt.hash(updateData.password, 10);
+    }
+    
+    const result = await this.usersRepository.update(id, updateData);
 
     if (result.affected === 0) {
       throw new NotFoundException(`Usuário com ID ${id} não encontrado`);

--- a/src/validators/cep.validator.ts
+++ b/src/validators/cep.validator.ts
@@ -1,0 +1,31 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
+export function IsValidCEP(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidCEP',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (!value) return true; // Opcional
+          if (typeof value !== 'string') return false;
+
+          // Remove máscara
+          const cleanCep = value.replace(/\D/g, '');
+          
+          // Deve ter exatamente 8 dígitos
+          return cleanCep.length === 8;
+        },
+        defaultMessage() {
+          return 'CEP deve ter 8 dígitos';
+        },
+      },
+    });
+  };
+}
+
+export function cleanCep(cepWithMask: string): string {
+  return cepWithMask.replace(/\D/g, '');
+}

--- a/src/validators/cpf.validator.ts
+++ b/src/validators/cpf.validator.ts
@@ -1,0 +1,29 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { cpf } from 'cpf-cnpj-validator';
+
+export function IsValidCPF(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidCPF',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'string') return false;
+
+          const cleanCpf = value.replace(/\D/g, '');
+
+          return cpf.isValid(cleanCpf);
+        },
+        defaultMessage() {
+          return 'CPF deve ser válido';
+        },
+      },
+    });
+  };
+}
+
+export function cleanCpf(cpfWithMask: string): string {
+  return cpfWithMask.replace(/\D/g, '');
+}

--- a/src/validators/phone.validator.ts
+++ b/src/validators/phone.validator.ts
@@ -1,0 +1,31 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
+export function IsValidPhone(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidPhone',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (!value) return true; // Opcional
+          if (typeof value !== 'string') return false;
+
+          // Remove máscara
+          const cleanPhone = value.replace(/\D/g, '');
+          
+          // Deve ter 10 ou 11 dígitos (com ou sem 9 no celular)
+          return cleanPhone.length === 10 || cleanPhone.length === 11;
+        },
+        defaultMessage() {
+          return 'Telefone deve ter 10 ou 11 dígitos';
+        },
+      },
+    });
+  };
+}
+
+export function cleanPhone(phoneWithMask: string): string {
+  return phoneWithMask.replace(/\D/g, '');
+}


### PR DESCRIPTION
Este PR implementa o tratamento e a validação dos campos cpf, numero e cep, assegurando que os dados sejam armazenados sem máscara no banco de dados, independentemente da formatação recebida do frontend — desde que os valores sejam válidos.